### PR TITLE
Refresh Page when User Token is Invalidated

### DIFF
--- a/app/scripts/controllers/myrides.js
+++ b/app/scripts/controllers/myrides.js
@@ -25,8 +25,22 @@ app.controller('MyridesController', [
     $scope.emailAddresses = {};
     var updateRides = function () {
       //getPastRides and getFutureRides modify $scope.trips adding .future and .past
-      planService.getFutureRides($http, $scope, ipCookie);
-      planService.getPastRides($http, $scope, ipCookie);
+      planService.getFutureRides($http, $scope, ipCookie)
+      .catch(function(e){
+        // If get rides call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Future Rides Call Error', e);
+          $window.location.reload();
+        }
+      });
+      planService.getPastRides($http, $scope, ipCookie)
+      .catch(function(e){
+        // If get rides call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Past Rides Call Error', e);
+          $window.location.reload();
+        }
+      });
     };
     updateRides();
     $scope.$on('LoginController:login', function () {

--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -192,10 +192,16 @@ app.controller('PlanController', [
           callback();
         }
       }).catch(function(e){
-        //if status is -1 it's OK -- the XHR was cancelled. otherwise report error
-        if(e.status > 0){
-          //bootbox.alert( $translate.instant('service_error') );
+        // If plan call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Plan Call Error', e);
+          $window.location.reload();
         }
+        
+        //if status is -1 it's OK -- the XHR was cancelled. otherwise report error
+        //if(e.status > 0){
+          //bootbox.alert( $translate.instant('service_error') );
+        //}
       });  //formerly _bookTrip();
     };
     $scope.itineraries = planService.transitResult || [];
@@ -327,6 +333,12 @@ app.controller('PlanController', [
       planService.postItineraryRequest($http).then(function (response) {
         success(response.data);
       }).catch(function (e) {
+        // If plan call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Plan Call Error', e);
+          $window.location.reload();
+        }
+        
         //if status is -1 it's OK -- the XHR was cancelled. otherwise report error
         if (e.status > 0) {
           //bootbox.alert($translate.instant('service_error'));

--- a/app/scripts/services/plan.js
+++ b/app/scripts/services/plan.js
@@ -1018,7 +1018,8 @@ angular.module('oneClickApp').service('LocationSearch', [
   'localStorageService',
   '$filter',
   'planService',
-  function ($http, $q, localStorageService, $filter, planService) {
+  '$window',
+  function ($http, $q, localStorageService, $filter, planService, $window) {
     var countryFilter = $filter('noCountry');
     var urlPrefix = '//' + APIHOST + '/';
     var autocompleteService = new google.maps.places.AutocompleteService();
@@ -1027,7 +1028,8 @@ angular.module('oneClickApp').service('LocationSearch', [
     var recentsConfig = planService.getHeaders();
     var getRecentSearches = function(){
       //get the recent searches
-      $http.get(urlPrefix + '/api/v1/places/recent', recentsConfig).then(function (response) {
+      $http.get(urlPrefix + '/api/v1/places/recent', recentsConfig)
+      .then(function (response) {
         if (!response.data) {
           return;
         }
@@ -1036,6 +1038,13 @@ angular.module('oneClickApp').service('LocationSearch', [
           angular.forEach(data.places, function (place) {
             recentRemoteSearches[place.name] = place;
           });
+        }
+      })
+      .catch(function(e) {
+        // If places call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Recent Places Call Error', e);
+          $window.location.reload();
         }
       });
     };
@@ -1144,7 +1153,8 @@ angular.module('oneClickApp').service('LocationSearch', [
       this.savedPlaceResults = [];
       this.poiData = [];
       var that = this;
-      $http.get(urlPrefix + 'api/v1/places/search?include_user_pois=true&search_string=%25' + text + '%25', config).then(function (response) {
+      $http.get(urlPrefix + 'api/v1/places/search?include_user_pois=true&search_string=%25' + text + '%25', config)
+      .then(function (response) {
         if (!response.data) {
           console.error('no data');
         }
@@ -1164,6 +1174,13 @@ angular.module('oneClickApp').service('LocationSearch', [
           savedplaceaddresses: that.savedPlaceAddresses,
           poiData: that.poiData
         });
+      })
+      .catch(function(e) {
+        // If places call errors out due to token invalidation, reload the page.
+        if(e.status === 401 || e.status === 404) {
+          console.error('Recent Places Call Error', e);
+          $window.location.reload();
+        }
       });
       return savedPlaceData.promise;
     };


### PR DESCRIPTION
Should work for token auth errors on the following calls:

- Places search (search, recent)
- My trips search (past, future)
- Logout
- Any page reload or new page view
- Plan trip